### PR TITLE
科目テンプレート編集の時にPrice per dayを必須にする

### DIFF
--- a/app/models/template_task.rb
+++ b/app/models/template_task.rb
@@ -2,5 +2,5 @@ class TemplateTask < ActiveRecord::Base
   attr_accessible :name, :position, :price_per_day
   acts_as_list
   has_many :project_tasks, order: :position
-  validates :name, presence: true
+  validates :name, :price_per_day, presence: true
 end


### PR DESCRIPTION
Price per dayが空の科目テンプレートをプロジェクトの科目設定で選択すると落ちる。
現在、科目設定に追加する際はProceを指定できないので、
科目テンプレートでPrice per dayを必須にすることでエラーを回避した。

（科目追加時にPrice per dayを入力できるのが理想だろうか）
