### PR TITLE
New, Deleteボタンの文字色が #666 になってしまう問題

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -28,3 +28,9 @@
 //
 // Example:
 // @linkColor: #ff0000;
+.btn-danger:visited {
+  color: #ffffff;
+}
+.btn-primary:visited {
+  color: #ffffff;
+}


### PR DESCRIPTION
ボタン文字色 #fff ではなくアンカーのスタイル

```
a:visited {
  color: #666;
}
```

が適用されてしまっている。
それぞれのボタンで visitedでも #fff にするように定義を追加しました。
