### PR TITLE
visitedの時文字色を変えない #22

### DIFF
--- a/app/assets/stylesheets/scaffolds.css.scss
+++ b/app/assets/stylesheets/scaffolds.css.scss
@@ -19,7 +19,7 @@ pre {
 }
 
 a {
-  color: #000;
+  color: #333;
   &:visited {
   }
   &:hover {


### PR DESCRIPTION
通常のリンクの文字色も他の文字色と異なるため修正しました。
- プロジェクト一覧
- 見積り出力
  などのリンク文字色に影響していました
