### PR TITLE
Specify timezone and change datetime format in project list

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -18,7 +18,7 @@
         <td><%= link_to project.id, project_path(project) %></td>
         <td><%= link_to project.name, project_dashboard_path(project)  %></td>
         <td><%= project.days_per_point %></td>
-        <td><%=l project.created_at %></td>
+        <td><%=l project.created_at, format: :long %></td>
         <td>
           <%= link_to t('.edit', :default => t("helpers.links.edit")),
                       edit_project_path(project), :class => 'btn btn-mini' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module Mitsumoritaro
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Tokyo'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
timezoneの指定をしました。(herokuがUTCになるため）

また、これにより、DBで保存されている日時が UTCに固定になり、PCの時刻ではなくなります。
過去のデータはそれのほど日時に依存するようなものはないのですが、念のため、注意
してください。
