### PR TITLE
Ruby2.1.0でspecが通らない箇所の対応

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -164,7 +164,6 @@ describe Project do
       it{ should eq 12.609520212918492 }
     end
     describe "total_price_with_buffer method" do
-      BigDecimal::limit(25)
       subject{ @project.total_price_with_buffer.to_f }
       it{ should eq 1525336.6547336343 }
     end


### PR DESCRIPTION
Ruby2.1.0で比較したいメソッドの戻り値がBigDecimal型に変更されたので、
値の比較をする前に戻り値型をfloat型に変換するようにしました。
