### PR TITLE
Fix spec to compensate floating point error

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -165,7 +165,7 @@ describe Project do
     end
     describe "total_price_with_buffer method" do
       subject{ @project.total_price_with_buffer.to_f }
-      it{ should eq 1525336.6547336343 }
+      it{ should be_within(1.0e-05).of(1525336.65473) }
     end
     describe "total_price_50 method" do
       subject{ @project.total_price_50 }


### PR DESCRIPTION
specで浮動小数点数を指定するときに、精度の指定をするようにしました。

MRI 2.1.0-p0 の環境でspecが通らなかった箇所のみ対応です。
