### PR TITLE
Ignore the directory 'coverage' in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /.rvmrc
 /.ruby-version
 /.ruby-gemset
+/coverage


### PR DESCRIPTION
rake specにより生成されるcoverageのディレクトリをgitでignoreするようにしました。
