### PR TITLE
Remove tilt warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require 'coffee_script'
+require 'sass'
 
 Bundler.require(*Rails.groups)
 


### PR DESCRIPTION
以下の警告の修正です。

WARN: tilt autoloading 'sass' in a non thread-safe way; explicit require 'sass' suggested.
WARN: tilt autoloading 'coffee_script' in a non thread-safe way; explicit require 'coffee_script' suggested.
