### PR TITLE
Remove Project#template_tasks which is not used

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,6 @@ class Project < ActiveRecord::Base
   has_many :categories, -> { order(:position) }, dependent: :destroy
   has_many :project_tasks, -> { order(:position) }, dependent: :destroy
   has_many :additional_costs, -> { order(:position) }, dependent: :destroy
-  has_many :template_tasks,-> { order("project_tasks.position") }, through: :project_tasks
   accepts_nested_attributes_for :project_tasks, allow_destroy: true
   validates :name, presence: true
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -9,7 +9,6 @@ describe Project do
     it { should respond_to(:categories) }
     it { should respond_to(:project_tasks) }
     it { should respond_to(:additional_costs) }
-    it { should respond_to(:template_tasks) }
   end
 
   describe "validation" do
@@ -222,7 +221,6 @@ describe Project do
       its(:categories) { should be_empty }
       its(:project_tasks) { should be_empty }
       its(:additional_costs) { should be_empty }
-      its(:template_tasks) { should be_empty }
     end
     describe "dup_additional_costs! method: " do
       before do
@@ -254,18 +252,6 @@ describe Project do
           @new_project.project_tasks.each_with_index do |pt, idx|
             pt.name.should eq org_project.project_tasks[idx].name
             pt.price_per_day.should eq org_project.project_tasks[idx].price_per_day
-          end
-        end
-      end
-      context "check template_tasks counts, " do
-        subject{ @new_project.template_tasks }
-        it { should have(2).items }
-      end
-      context "check template_tasks value, " do
-        specify do
-          @new_project.template_tasks.each_with_index do |tt, idx|
-            tt.name.should eq org_project.template_tasks[idx].name
-            tt.price_per_day.should eq org_project.template_tasks[idx].price_per_day
           end
         end
       end
@@ -343,18 +329,6 @@ describe Project do
           @new_project.project_tasks.each_with_index do |pt, idx|
             pt.name.should eq org_project.project_tasks[idx].name
             pt.price_per_day.should eq org_project.project_tasks[idx].price_per_day
-          end
-        end
-      end
-      context "check template_tasks counts, " do
-        subject{ @new_project.template_tasks }
-        it { should have(2).items }
-      end
-      context "check template_tasks values, " do
-        specify do
-          @new_project.template_tasks.each_with_index do |tt, idx|
-            tt.name.should eq org_project.template_tasks[idx].name
-            tt.price_per_day.should eq org_project.template_tasks[idx].price_per_day
           end
         end
       end


### PR DESCRIPTION
This method has not been used anywhere.
Before this patch, 'rspec ./spec/ --seed 57074' raise error

https://travis-ci.org/ESTCOSMO/mitsumottaro/jobs/24506998

There has been some problems as follows,
1. Duplicated 'order by project_tasks.position' in SQL was found.
2. On PGSQL, order by project_tasks.position does not work well sometimes.
3. This 'Project#template_tasks' has not been used.

The 1's problem can be fixed by removing the lambda expression of 'order'
from the declaration of :template_tasks, but 2's problem probably comes from
PostgreSQL behavior and it's hard to fix.

So this patch removes this unused declaration.
