### PR TITLE
Prevent the copy and paste from copying css style into the destination

### DIFF
--- a/app/assets/javascripts/angularjs/lib/content_editable.js.coffee
+++ b/app/assets/javascripts/angularjs/lib/content_editable.js.coffee
@@ -60,13 +60,13 @@ angular.module('mitsumottaroApp').directive 'contenteditable', ['$parse', ($pars
 
 
       updateModel = ->
-        html = elm.html()
-        if html == '<br>'
-          html = ''
-        if (!model.$viewValue? || model.$viewValue == "") && (!html? || html == "")
+        text = elm.text().replace /\r?\n/, ""
+        if (!model.$viewValue? || model.$viewValue == "") && (!text? || text == "")
           # do nothing
-        else if String(model.$viewValue) != html
-          model.$setViewValue(html)
+        else if String(model.$viewValue) != text
+          model.$setViewValue(text)
+        elm.html('')  # This line is necessory to remove '<br>'
+        elm.text(text)
 
       # initialize
       elm.text(model.$viewValue)


### PR DESCRIPTION
contenteditable 属性の要素をコピーして別の箇所にペーストすると、文字色等のstyleまでもペーストされてしまう問題を修正しました。（大項目をコピーして、中項目にペーストすると、文字が青くなり、しかも、リロードすると、HTMLエスケープされたタグが表示される状況でした。）
