### PR TITLE
Fix Ruby 1.9.3's rspec error

### DIFF
--- a/spec/views/template_tasks/index.html.erb_spec.rb
+++ b/spec/views/template_tasks/index.html.erb_spec.rb
@@ -1,4 +1,4 @@
-# coding utf-8
+# coding: utf-8
 require 'spec_helper'
 
 describe "template_tasks/index" do


### PR DESCRIPTION
File coding should be specified for Ruby 1.9.3
