### PR TITLE
MacOS Sierraで動作させるためlibv8の必須バージョンをあげる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '4.1.5'
 
 gem 'sqlite3'
 if ENV['TRAVIS']
-  gem "mysql2"
+  gem "mysql2", '~> 0.3.20'
   gem 'pg'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'acts_as_list'
 
 gem 'twitter-bootstrap-rails'
 gem 'therubyracer'
-gem 'libv8', '~> 3.11.8'
+gem 'libv8', '~> 3.16.14.19'
 gem 'less-rails'
 gem 'haml-rails'
 gem 'underscore-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     less-rails (2.5.0)
       actionpack (>= 3.1)
       less (~> 2.5.0)
-    libv8 (3.11.8.17)
+    libv8 (3.16.14.19)
     listen (2.7.8)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -124,7 +124,7 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    ref (1.0.5)
+    ref (2.0.0)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
       rspec-expectations (~> 3.0.0)
@@ -183,8 +183,8 @@ GEM
       sprockets (~> 2.8)
     sqlite3 (1.3.9)
     temple (0.6.7)
-    therubyracer (0.11.4)
-      libv8 (~> 3.11.8.12)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thor (0.19.1)
     thread_safe (0.3.4)
@@ -219,7 +219,7 @@ DEPENDENCIES
   haml-rails
   jquery-rails
   less-rails
-  libv8 (~> 3.11.8)
+  libv8 (~> 3.16.14.19)
   rails (= 4.1.5)
   rspec-activemodel-mocks
   rspec-rails
@@ -233,3 +233,6 @@ DEPENDENCIES
   twitter-bootstrap-rails
   uglifier (>= 1.0.3)
   underscore-rails
+
+BUNDLED WITH
+   1.15.4


### PR DESCRIPTION
http://rochefort.hatenablog.com/entry/2016/04/07/222405
```
$ gem list -rd '^libv8$'

*** REMOTE GEMS ***

libv8 (6.0.286.54.1, 5.3.332.38.5, 3.16.14.19, 3.16.14.15, 3.16.14.7, 3.16.14.5, 3.16.14.3, 3.16.14.1, 3.11.8.13, 3.11.8.3, 3.3.10.4)
    Platforms:
        3.3.10.4: amd64-freebsd-8, x86-darwin-10, x86-darwin-11
        3.11.8.3: x86-freebsd-9
        3.11.8.13: x86_64-darwin-11
        3.16.14.1: x86_64-darwin-10
        3.16.14.3: amd64-freebsd-9, x86_64-darwin-12, x86_64-solaris-2.11
        3.16.14.5: armv6l-linux
        3.16.14.7: x86_64-darwin-13
        3.16.14.15: universal.x86_64-darwin-13, universal.x86_64-darwin-14
        3.16.14.19: universal.x86_64-darwin-15, universal.x86_64-darwin-16
        5.3.332.38.5: armv7l-linux
        6.0.286.54.1: aarch64-linux, amd64-freebsd-10, amd64-freebsd-11, arm-linux, ruby,
                      universal-darwin-14, universal-darwin-15, universal-darwin-16,
                      x86-linux, x86_64-darwin-14, x86_64-darwin-15, x86_64-darwin-16,
                      x86_64-freebsd-10, x86_64-freebsd-11, x86_64-linux
    Author: Charles Lowell
    Homepage: http://github.com/cowboyd/libv8

    Distribution of the V8 JavaScript engine
```

Sierra(universal.x86_64-darwin-16)の場合、libv8 -v 3.16.14.19 しか入らなかったので Gemfileのバージョン指定を上げました。

``` bundle update therubyracer ``` をする必要があります。

Gemfile.lock もコミットした方がよければコミットします....

というか、この指定方法だと古いOSで問題が出る?